### PR TITLE
Fix bug where cache assumed all routes come from the same host

### DIFF
--- a/routeutils/utils.py
+++ b/routeutils/utils.py
@@ -146,14 +146,16 @@ def cacheStations(routingTable, stationTable):
     """
     ptRT = routingTable
     for st in ptRT.keys():
+        services = set(urlparse(rt.address).netloc for rt in ptRT[st])
         for rt in ptRT[st]:
             if rt.service == 'station':
                 result = getStationCache(st, rt)
+            for service in services:
                 try:
-                    stationTable[urlparse(rt.address).netloc][st] = result
+                    stationTable[service][st] = result
                 except KeyError:
-                    stationTable[urlparse(rt.address).netloc] = dict()
-                    stationTable[urlparse(rt.address).netloc][st] = result
+                    stationTable[service] = dict()
+                    stationTable[service][st] = result
 
 
 def addRoutes(fileName, **kwargs):

--- a/routeutils/utils.py
+++ b/routeutils/utils.py
@@ -150,12 +150,12 @@ def cacheStations(routingTable, stationTable):
         for rt in ptRT[st]:
             if rt.service == 'station':
                 result = getStationCache(st, rt)
-            for service in services:
-                try:
-                    stationTable[service][st] = result
-                except KeyError:
-                    stationTable[service] = dict()
-                    stationTable[service][st] = result
+        for service in services:
+            try:
+                stationTable[service][st] = result
+            except KeyError:
+                stationTable[service] = dict()
+                stationTable[service][st] = result
 
 
 def addRoutes(fileName, **kwargs):


### PR DESCRIPTION
Hi Javier, my routing service exploded when I requested WFCatalog routes with the new station cache. This happens because you cache stations in a dictionary by the URL netloc (e.g. geofon.gfz-potsdam.de) only for `FDSN-Station`. Because INGV has a different host for the WFCatalog the cache would be a non-existent key and crash. Changed so we add an entry for each unique host to the cache.

Best,
Mathijs