### PR TITLE
Prevent Internal Server Error with format=fdsn and service=unknown

### DIFF
--- a/routeutils/utils.py
+++ b/routeutils/utils.py
@@ -537,7 +537,7 @@ class FDSNRules(dict):
             # This is empty and then it can be already added
             # toAdd["services"] = [service]
         except Exception:
-            raise
+            return
 
         toAdd["services"] = [{"name": service, "url": url}]
 


### PR DESCRIPTION
This PR fixes #71.

Test:

```bash
$ pwd
~/work/projects/routing
```

`data/routing.xml`:
```
<?xml version="1.0" encoding="utf-8"?>
<ns0:routing xmlns:ns0="http://geofon.gfz-potsdam.de/ns/Routing/1.0/">
<ns0:route networkCode="1A" stationCode="*" locationCode="*" streamCode="*">
	<ns0:station address="http://ws.resif.fr/fdsnws/station/1/query" priority="1" start="2009-01-01T00:00:00" end="2012-12-31T23:59:59"/>
	<ns0:dataselect address="http://ws.resif.fr/fdsnws/dataselect/1/query" priority="1" start="2009-01-01T00:00:00" end="2012-12-31T23:59:59"/>
	<ns0:availability address="http://ws.resif.fr/fdsnws/availability/1/query" priority="1" start="2009-01-01T00:00:00" end="2012-12-31T23:59:59"/>
	<ns0:timeseries address="http://ws.resif.fr/resifws/timeseries/1/query" priority="1" start="2009-01-01T00:00:00" end="2012-12-31T23:59:59"/>
	<ns0:timeseriesplot address="http://ws.resif.fr/resifws/timeseriesplot/1/query" priority="1" start="2009-01-01T00:00:00" end="2012-12-31T23:59:59"/>
	<ns0:wfcatalog address="http://ws.resif.fr/eidaws/wfcatalog/1/query" priority="1" start="2009-01-01T00:00:00" end="2012-12-31T23:59:59"/>
</ns0:route>
</ns0:routing>
```

Harvest:
```
cd data && ./updateAll.py --loglevel INFO
```

`eidaws-routing.sh`:
```bash
#!/bin/bash

set -e -x

python3 -m venv venv
BIN=$(realpath venv/bin)
${BIN}/python -m pip install --upgrade pip 
${BIN}/python -m pip install uwsgi

${BIN}/uwsgi --http :9090 --wsgi-file $(realpath routing.py)
```

Install and run the service:
```
$ chmod +x eidaws-routing.sh && ./eidaws-routing.sh
```

From another console window run a few tests:
```
$ curl -o - "http://localhost:9090/eidaws/routing/1/version"
1.2.1
$ curl -o - "http://localhost:9090/eidaws/routing/1/query?net=1A&service=timeseries&format=fdsn"
{"version": 1, "datacenters": []}
$ curl -o - "http://localhost:9090/eidaws/routing/1/query?net=1A&service=dataselect&format=fdsn"
{"version": 1, "datacenters": [{"name": "RESIF", "website": "https://www.resif.fr", "fullName": "RESIF Data Centre", "summary": "French seismologic and geodetic network", "repositories": [{"name": "archive", "description": "Archive of continuous seismological data", "website": "http://seismology.resif.fr/", "services": [{"name": "fdsnws-dataselect-1", "description": "Access to raw time series data", "url": "http://ws.resif.fr/fdsnws/dataselect/1/"}, {"name": "fdsnws-station-1", "description": "Access to metadata describing raw time series data", "url": "http://ws.resif.fr/fdsnws/station/1/"}, {"name": "eidaws-wfcatalog", "description": "EIDA WFCatalog service", "url": "http://ws.resif.fr/eidaws/wfcatalog/1/"}], "datasets": [{"priority": 1, "starttime": "2009-01-01T00:00:00", "network": "1A", "endtime": "2012-12-31T23:59:59", "services": [{"name": "fdsnws-dataselect-1", "url": "http://ws.resif.fr/fdsnws/dataselect/1/"}]}]}]}]}
$ curl -o - "http://localhost:9090/eidaws/routing/1/query?net=1A&service=dataselect&format=post"
http://ws.resif.fr/fdsnws/dataselect/1/query
1A * * * 2009-01-01T00:00:00 2012-12-31T23:59:59
```

Hope this helps.